### PR TITLE
Fix cluster setup and teardown

### DIFF
--- a/k8s/setup_cluster.sh
+++ b/k8s/setup_cluster.sh
@@ -24,7 +24,7 @@ gcloud beta container clusters create $CLUSTER_NAME \
     --network $NETWORK_NAME  --create-subnetwork=name=$NETWORK_NAME-subnet,range=10.0.0.0/24 \
     --services-ipv4-cidr=10.0.1.0/24 --default-max-pods-per-node=110 \
     --zone=$ZONE \
-    --cluster-version "1.16.12-gke.3" \
+    --cluster-version "1.15.12-gke.13" \
     --machine-type "n1-standard-1" --num-nodes "2" \
     --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "50" \
     --enable-network-policy --enable-ip-alias --no-enable-autoupgrade --no-enable-stackdriver-kubernetes \

--- a/k8s/teardown_cluster.sh
+++ b/k8s/teardown_cluster.sh
@@ -18,8 +18,8 @@ gcloud config set compute/region $REGION
 gcloud config set compute/zone $ZONE
 
 gcloud beta container clusters delete $CLUSTER_NAME --quiet
-gcloud compute firewall-rules $FIREWALL_NAME-nodeport --quiet
-gcloud compute firewall-rules $FIREWALL_NAME-ssh --quiet
+gcloud compute firewall-rules delete $FIREWALL_NAME-nodeport --quiet
+gcloud compute firewall-rules delete $FIREWALL_NAME-ssh --quiet
 gcloud compute networks delete $NETWORK_NAME  --quiet
 
 # TODO


### PR DESCRIPTION
This PR is for:

- Change k8s version to the latest stable supported GKE release, Check here: https://cloud.google.com/kubernetes-engine/docs/release-notes#version_updates
- Fix and update `teardown_cluster.sh` script to delete firewall rules