### PR TITLE
Improve readme for container fundamental training

### DIFF
--- a/container_fundamentals/00_setup/README.md
+++ b/container_fundamentals/00_setup/README.md
@@ -10,7 +10,11 @@ You wil be asked about the project name.
 
 ## SSH into the new VM
 
-Visit https://console.cloud.google.com/compute/instances and click the `Connect SSH` button.
+```bash
+gcloud compute ssh container-fundamentals
+```
+
+or visit https://console.cloud.google.com/compute/instances and click the `Connect SSH` button.
 
 ## Install docker
 

--- a/container_fundamentals/01_hello-docker/README.md
+++ b/container_fundamentals/01_hello-docker/README.md
@@ -20,7 +20,11 @@ apache2ctl -DFOREGROUND
 
 ## Visit the welcome page in your browser 
 
-To get the external IP you can visit https://console.cloud.google.com/networking/addresses/.
+To get the external IP of the vm use
+```bash
+gcloud compute instances list --filter="name=(container-fundamentals)"
+```
+or visit https://console.cloud.google.com/networking/addresses/.
 
 ## Stop the process in the Docker container
 

--- a/container_fundamentals/03_container-lifecycle/README.md
+++ b/container_fundamentals/03_container-lifecycle/README.md
@@ -17,6 +17,11 @@ docker stop my-nginx
 
 Stop the started container. The main process inside the container will receive `SIGTERM`, and after a grace period, `SIGKILL`.
 
+Check the exit code
+```bash
+docker ps -a
+```
+
 ## Restart a stopped container
 
 ```bash
@@ -28,6 +33,11 @@ docker restart my-nginx
 If you have e.g. an hanging container, it's possible to send the `SIGKILL` signal directly. Try
 ```bash
 docker kill my-nginx
+```
+
+Check the exit code and compare it to the previous
+```bash
+docker ps -a
 ```
 
 The container is still startable

--- a/container_fundamentals/06_build-images-interactive/README.md
+++ b/container_fundamentals/06_build-images-interactive/README.md
@@ -58,3 +58,9 @@ Verify that your file still exists in the new container
 ```bash
 ls /
 ```
+
+## Cleanup
+
+```bash
+docker rm -f $(docker ps -qa)
+```


### PR DESCRIPTION
I've done the container fundamentals training and would like to add some improvements to the documentation.

- One cleanup step is missing in `06_build-images-interactive/README.md` which could confuse students in later chapters
- It would be interesting to check the exit code in `03_container-lifecycle/README.md` when killing and stopping a container
- in `00_setup/README.md` and `01_hello-docker/README.md` the steps would be easier when `gcloud` is beeing used to connect via SSH and to fetch the public ip address. But I'm not sure if students have a working `gcloud` command line tool installed (I assume it because its needed for `00_setup`).