### PR TITLE
Make setup scripts more resilient

### DIFF
--- a/container_fundamentals/00_setup/setup.sh
+++ b/container_fundamentals/00_setup/setup.sh
@@ -23,29 +23,75 @@ gcloud config set compute/region $REGION
 gcloud config set compute/zone $ZONE
 
 # create networks
-gcloud compute networks create $NETWORK_NAME --project=$PROJECT_NAME \
-  --subnet-mode=custom --mtu=1460 --bgp-routing-mode=regional
-gcloud compute networks subnets create $NETWORK_NAME-subnet --project=$PROJECT_NAME \
-  --range=10.0.0.0/24 --network=$NETWORK_NAME --region=$REGION
+response_network=`gcloud compute networks list --filter="name=$NETWORK_NAME" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_network" ]
+then
+  gcloud compute networks create $NETWORK_NAME --project=$PROJECT_NAME \
+    --subnet-mode=custom --mtu=1460 --bgp-routing-mode=regional
+else
+      echo "Network $response_network already exists, skip creation"
+fi
+
+#create subnet
+response_subnet=`gcloud compute networks subnets list --filter="name=$NETWORK_NAME-subnet" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_subnet" ]
+then
+  gcloud compute networks subnets create $NETWORK_NAME-subnet --project=$PROJECT_NAME \
+    --range=10.0.0.0/24 --network=$NETWORK_NAME --region=$REGION
+else
+      echo "Subnet $response_subnet already exists, skip creation"
+fi
 
 # create VM
-gcloud beta compute --project=$PROJECT_NAME instances create $VM_NAME \
-  --zone=$ZONE --machine-type=n2-standard-2 \
-  --subnet=$NETWORK_NAME-subnet --network-tier=PREMIUM \
-  --maintenance-policy=MIGRATE \
-  --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append \
-  --tags=http-server,https-server \
-  --image=ubuntu-2004-focal-v20201028 --image-project=ubuntu-os-cloud \
-  --boot-disk-size=100GB --boot-disk-type=pd-standard --boot-disk-device-name=container-training \
-  --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring --reservation-affinity=any
+response_instance=`gcloud compute instances list --filter="name=$VM_NAME" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_instance" ]
+then
+  gcloud beta compute --project=$PROJECT_NAME instances create $VM_NAME \
+    --zone=$ZONE --machine-type=n2-standard-2 \
+    --subnet=$NETWORK_NAME-subnet --network-tier=PREMIUM \
+    --maintenance-policy=MIGRATE \
+    --scopes=https://www.googleapis.com/auth/devstorage.read_only,https://www.googleapis.com/auth/logging.write,https://www.googleapis.com/auth/monitoring.write,https://www.googleapis.com/auth/servicecontrol,https://www.googleapis.com/auth/service.management.readonly,https://www.googleapis.com/auth/trace.append \
+    --tags=http-server,https-server \
+    --image=ubuntu-2004-focal-v20201028 --image-project=ubuntu-os-cloud \
+    --boot-disk-size=100GB --boot-disk-type=pd-standard --boot-disk-device-name=container-training \
+    --no-shielded-secure-boot --shielded-vtpm --shielded-integrity-monitoring --reservation-affinity=any
+else
+      echo "Instance $response_instance already exists, skip creation"
+fi
 
 # create firewall rules
-gcloud compute --project=$PROJECT_NAME firewall-rules create $FIREWALL_NAME-allow-http \
-  --direction=INGRESS --priority=1000 --network=$NETWORK_NAME --action=ALLOW \
-  --rules=tcp:80 --source-ranges=0.0.0.0/0 --target-tags=http-server
-gcloud compute --project=$PROJECT_NAME firewall-rules create $FIREWALL_NAME-allow-https \
-  --direction=INGRESS --priority=1000 --network=$NETWORK_NAME --action=ALLOW \
-  --rules=tcp:443 --source-ranges=0.0.0.0/0 --target-tags=https-server
-gcloud compute --project=$PROJECT_NAME firewall-rules create $FIREWALL_NAME-allow-ssh \
-  --direction=INGRESS --priority=1000 --network=$NETWORK_NAME --action=ALLOW \
-  --rules=tcp:22 --source-ranges=0.0.0.0/0
+response_firewall_http=`gcloud compute firewall-rules list --filter="$FIREWALL_NAME-allow-http" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_firewall_http" ]
+then
+  gcloud compute --project=$PROJECT_NAME firewall-rules create $FIREWALL_NAME-allow-http \
+    --direction=INGRESS --priority=1000 --network=$NETWORK_NAME --action=ALLOW \
+    --rules=tcp:80 --source-ranges=0.0.0.0/0 --target-tags=http-server
+else
+      echo "Firewall $response_firewall_http already exists, skip creation"
+fi
+
+response_firewall_https=`gcloud compute firewall-rules list --filter="$FIREWALL_NAME-allow-https" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_firewall_https" ]
+then
+  gcloud compute --project=$PROJECT_NAME firewall-rules create $FIREWALL_NAME-allow-https \
+    --direction=INGRESS --priority=1000 --network=$NETWORK_NAME --action=ALLOW \
+    --rules=tcp:443 --source-ranges=0.0.0.0/0 --target-tags=https-server
+else
+      echo "Firewall $response_firewall_https already exists, skip creation"
+fi
+
+response_firewall_ssh=`gcloud compute firewall-rules list --filter="$FIREWALL_NAME-allow-ssh" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_firewall_ssh" ]
+then
+  gcloud compute --project=$PROJECT_NAME firewall-rules create $FIREWALL_NAME-allow-ssh \
+    --direction=INGRESS --priority=1000 --network=$NETWORK_NAME --action=ALLOW \
+    --rules=tcp:22 --source-ranges=0.0.0.0/0
+else
+      echo "Firewall $response_firewall_ssh already exists, skip creation"
+fi

--- a/k8s_fundamentals/00_setup/setup_cluster.sh
+++ b/k8s_fundamentals/00_setup/setup_cluster.sh
@@ -22,49 +22,93 @@ gcloud config set compute/region $REGION
 gcloud config set compute/zone $ZONE
 
 # create networks
-gcloud compute networks create $NETWORK_NAME --project=$PROJECT_NAME \
-  --subnet-mode=custom --mtu=1460 --bgp-routing-mode=regional
-gcloud compute networks subnets create $NETWORK_NAME-subnet --project=$PROJECT_NAME \
-  --range=10.0.0.0/24 --network=$NETWORK_NAME --region=$REGION
+response_network=`gcloud compute networks list --filter="name=$NETWORK_NAME" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_network" ]
+then
+  gcloud compute networks create $NETWORK_NAME --project=$PROJECT_NAME \
+    --subnet-mode=custom --mtu=1460 --bgp-routing-mode=regional
+else
+      echo "Network $response_network already exists, skip creation"
+fi
+
+#create subnet
+response_subnet=`gcloud compute networks subnets list --filter="name=$NETWORK_NAME-subnet" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_subnet" ]
+then
+  gcloud compute networks subnets create $NETWORK_NAME-subnet --project=$PROJECT_NAME \
+    --range=10.0.0.0/24 --network=$NETWORK_NAME --region=$REGION
+else
+      echo "Subnet $response_network already exists, skip creation"
+fi
 
 # create cluster
-gcloud beta container clusters create $CLUSTER_NAME \
-  --network "projects/$PROJECT_NAME/global/networks/$NETWORK_NAME" --subnetwork "projects/$PROJECT_NAME/regions/$REGION/subnetworks/$NETWORK_NAME-subnet" \
-  --services-ipv4-cidr=10.0.1.0/24 --default-max-pods-per-node=110 \
-  --zone=$ZONE \
-  --cluster-version "1.18.12-gke.1205" \
-  --machine-type "n1-standard-4" --num-nodes "2" \
-  --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --default-max-pods-per-node "110" \
-  --enable-network-policy --enable-ip-alias \
-  --no-enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0 \
-  --no-enable-basic-auth --metadata disable-legacy-endpoints=true \
-  --no-enable-stackdriver-kubernetes --no-enable-master-authorized-networks \
-  --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
-  --addons HorizontalPodAutoscaling,HttpLoadBalancing
+response_cluster=`gcloud beta container clusters list --filter="name=$CLUSTER_NAME" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_cluster" ]
+then
+  gcloud beta container clusters create $CLUSTER_NAME \
+    --network "projects/$PROJECT_NAME/global/networks/$NETWORK_NAME" --subnetwork "projects/$PROJECT_NAME/regions/$REGION/subnetworks/$NETWORK_NAME-subnet" \
+    --services-ipv4-cidr=10.0.1.0/24 --default-max-pods-per-node=110 \
+    --zone=$ZONE \
+    --cluster-version "1.18" \
+    --machine-type "n1-standard-4" --num-nodes "2" \
+    --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --default-max-pods-per-node "110" \
+    --enable-network-policy --enable-ip-alias \
+    --no-enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0 \
+    --no-enable-basic-auth --metadata disable-legacy-endpoints=true \
+    --no-enable-stackdriver-kubernetes --no-enable-master-authorized-networks \
+    --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
+    --addons HorizontalPodAutoscaling,HttpLoadBalancing
+else
+      echo "Cluster $response_cluster already exists, skip creation"
+fi
 
 ### add firewall rule for ingress gateway
-gcloud compute firewall-rules create $FIREWALL_NAME-ingress-gateway \
-  --network $NETWORK_NAME \
-  --direction=INGRESS \
-  --action=ALLOW \
-  --source-ranges=0.0.0.0/0 \
-  --rules=tcp:80,tcp:443
+response_firewall_ingress=`gcloud compute firewall-rules list --filter="$FIREWALL_NAME-ingress-gateway" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_firewall_ingress" ]
+then
+  gcloud compute firewall-rules create $FIREWALL_NAME-ingress-gateway \
+    --network $NETWORK_NAME \
+    --direction=INGRESS \
+    --action=ALLOW \
+    --source-ranges=0.0.0.0/0 \
+    --rules=tcp:80,tcp:443
+else
+      echo "Firewall $response_firewall_ingress already exists, skip creation"
+fi
 
 ### add ssh access for nodes
-gcloud compute firewall-rules create $FIREWALL_NAME-ssh \
-  --direction=INGRESS \
-  --network=$NETWORK_NAME \
-  --action=ALLOW \
-  --source-ranges=0.0.0.0/0 \
-  --rules=tcp:22
+response_firewall_ssh=`gcloud compute firewall-rules list --filter="$FIREWALL_NAME-ssh" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_firewall_ssh" ]
+then
+  gcloud compute firewall-rules create $FIREWALL_NAME-ssh \
+    --direction=INGRESS \
+    --network=$NETWORK_NAME \
+    --action=ALLOW \
+    --source-ranges=0.0.0.0/0 \
+    --rules=tcp:22
+else
+      echo "Firewall $response_firewall_ssh already exists, skip creation"
+fi
 
 ### add access to NodePort services
-gcloud compute firewall-rules create $FIREWALL_NAME-nodeport \
-  --direction=INGRESS \
-  --network=$NETWORK_NAME \
-  --action=ALLOW \
-  --source-ranges=0.0.0.0/0 \
-  --rules=tcp:30000-32767
+response_firewall_nodeport=`gcloud compute firewall-rules list --filter="$FIREWALL_NAME-nodeport" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_firewall_nodeport" ]
+then
+  gcloud compute firewall-rules create $FIREWALL_NAME-nodeport \
+    --direction=INGRESS \
+    --network=$NETWORK_NAME \
+    --action=ALLOW \
+    --source-ranges=0.0.0.0/0 \
+    --rules=tcp:30000-32767
+else
+      echo "Firewall $response_firewall_nodeport already exists, skip creation"
+fi
 
 # connect to cluster
 gcloud container clusters get-credentials $CLUSTER_NAME 

--- a/k8s_servicemesh/00_setup_cluster/setup_cluster.sh
+++ b/k8s_servicemesh/00_setup_cluster/setup_cluster.sh
@@ -21,50 +21,95 @@ gcloud config set project $PROJECT_NAME
 gcloud config set compute/region $REGION
 gcloud config set compute/zone $ZONE
 
+
 # create networks
-gcloud compute networks create $NETWORK_NAME --project=$PROJECT_NAME \
-  --subnet-mode=custom --mtu=1460 --bgp-routing-mode=regional
-gcloud compute networks subnets create $NETWORK_NAME-subnet --project=$PROJECT_NAME \
-  --range=10.0.0.0/24 --network=$NETWORK_NAME --region=$REGION
+response_network=`gcloud compute networks list --filter="name=$NETWORK_NAME" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_network" ]
+then
+  gcloud compute networks create $NETWORK_NAME --project=$PROJECT_NAME \
+    --subnet-mode=custom --mtu=1460 --bgp-routing-mode=regional
+else
+      echo "Network $response_network already exists, skip creation"
+fi
+
+#create subnet
+response_subnet=`gcloud compute networks subnets list --filter="name=$NETWORK_NAME-subnet" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_subnet" ]
+then
+  gcloud compute networks subnets create $NETWORK_NAME-subnet --project=$PROJECT_NAME \
+    --range=10.0.0.0/24 --network=$NETWORK_NAME --region=$REGION
+else
+      echo "Subnet $response_network already exists, skip creation"
+fi
 
 # create cluster
-gcloud beta container clusters create $CLUSTER_NAME \
-  --network "projects/$PROJECT_NAME/global/networks/$NETWORK_NAME" --subnetwork "projects/$PROJECT_NAME/regions/$REGION/subnetworks/$NETWORK_NAME-subnet" \
-  --services-ipv4-cidr=10.0.1.0/24 --default-max-pods-per-node=110 \
-  --zone=$ZONE \
-  --cluster-version "1.18.12-gke.1205" \
-  --machine-type "n1-standard-4" --num-nodes "2" \
-  --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --default-max-pods-per-node "110" \
-  --enable-network-policy --enable-ip-alias \
-  --no-enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0 \
-  --no-enable-basic-auth --metadata disable-legacy-endpoints=true \
-  --no-enable-stackdriver-kubernetes --no-enable-master-authorized-networks \
-  --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
-  --addons HorizontalPodAutoscaling,HttpLoadBalancing
+response_cluster=`gcloud beta container clusters list --filter="name=$CLUSTER_NAME" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_cluster" ]
+then
+  gcloud beta container clusters create $CLUSTER_NAME \
+    --network "projects/$PROJECT_NAME/global/networks/$NETWORK_NAME" --subnetwork "projects/$PROJECT_NAME/regions/$REGION/subnetworks/$NETWORK_NAME-subnet" \
+    --services-ipv4-cidr=10.0.1.0/24 --default-max-pods-per-node=110 \
+    --zone=$ZONE \
+    --cluster-version "1.18" \
+    --machine-type "n1-standard-4" --num-nodes "2" \
+    --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" --default-max-pods-per-node "110" \
+    --enable-network-policy --enable-ip-alias \
+    --no-enable-autoupgrade --enable-autorepair --max-surge-upgrade 1 --max-unavailable-upgrade 0 \
+    --no-enable-basic-auth --metadata disable-legacy-endpoints=true \
+    --no-enable-stackdriver-kubernetes --no-enable-master-authorized-networks \
+    --scopes "https://www.googleapis.com/auth/devstorage.read_only","https://www.googleapis.com/auth/logging.write","https://www.googleapis.com/auth/monitoring","https://www.googleapis.com/auth/servicecontrol","https://www.googleapis.com/auth/service.management.readonly","https://www.googleapis.com/auth/trace.append" \
+    --addons HorizontalPodAutoscaling,HttpLoadBalancing
+else
+      echo "Cluster $response_cluster already exists, skip creation"
+fi
 
 ### add firewall rule for ingress gateway
-gcloud compute firewall-rules create $FIREWALL_NAME-ingress-gateway \
-  --network $NETWORK_NAME \
-  --direction=INGRESS \
-  --action=ALLOW \
-  --source-ranges=0.0.0.0/0 \
-  --rules=tcp:80,tcp:443
+response_firewall_ingress=`gcloud compute firewall-rules list --filter="$FIREWALL_NAME-ingress-gateway" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_firewall_ingress" ]
+then
+  gcloud compute firewall-rules create $FIREWALL_NAME-ingress-gateway \
+    --network $NETWORK_NAME \
+    --direction=INGRESS \
+    --action=ALLOW \
+    --source-ranges=0.0.0.0/0 \
+    --rules=tcp:80,tcp:443
+else
+      echo "Firewall $response_firewall_ingress already exists, skip creation"
+fi
 
 ### add ssh access for nodes
-gcloud compute firewall-rules create $FIREWALL_NAME-ssh \
-  --direction=INGRESS \
-  --network=$NETWORK_NAME \
-  --action=ALLOW \
-  --source-ranges=0.0.0.0/0 \
-  --rules=tcp:22
+response_firewall_ssh=`gcloud compute firewall-rules list --filter="$FIREWALL_NAME-ssh" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_firewall_ssh" ]
+then
+  gcloud compute firewall-rules create $FIREWALL_NAME-ssh \
+    --direction=INGRESS \
+    --network=$NETWORK_NAME \
+    --action=ALLOW \
+    --source-ranges=0.0.0.0/0 \
+    --rules=tcp:22
+else
+      echo "Firewall $response_firewall_ssh already exists, skip creation"
+fi
 
 ### add access to NodePort services
-gcloud compute firewall-rules create $FIREWALL_NAME-nodeport \
-  --direction=INGRESS \
-  --network=$NETWORK_NAME \
-  --action=ALLOW \
-  --source-ranges=0.0.0.0/0 \
-  --rules=tcp:30000-32767
+response_firewall_nodeport=`gcloud compute firewall-rules list --filter="$FIREWALL_NAME-nodeport" --format="value(name)" --project=$PROJECT_NAME`
+
+if [ -z "$response_firewall_nodeport" ]
+then
+  gcloud compute firewall-rules create $FIREWALL_NAME-nodeport \
+    --direction=INGRESS \
+    --network=$NETWORK_NAME \
+    --action=ALLOW \
+    --source-ranges=0.0.0.0/0 \
+    --rules=tcp:30000-32767
+else
+      echo "Firewall $response_firewall_nodeport already exists, skip creation"
+fi
 
 # connect to cluster
 gcloud container clusters get-credentials $CLUSTER_NAME 


### PR DESCRIPTION
I added some lookups to the setup scripts which prevent duplicate resource creation and errors. Attendees should be now able to run the scripts multiple times.

I also changed the used Kubernetes version from `1.18.12-gke.1205` to a more generic `1.18 ` so we don't have to keep up with the supported patch version of GCP. By only using `1.18` gcloud will use the newest `1.18` version, which should be fine.