### PR TITLE
Avoid using [training-repo] placeholder

### DIFF
--- a/k1_fundamentals/00_setup/README.md
+++ b/k1_fundamentals/00_setup/README.md
@@ -47,10 +47,9 @@ After you entered the container, verify the setup:
 
 ```bash
 ### executed inside the tooling container
+export TRAINING_DIR=`pwd`/mnt/trainings/k1_fundamentals
+cd $TRAINING_DIR
 
-cd mnt/k1_fundamentals
-pwd 
-#### /home/kubermatic/mnt/k1_fundamentals
 ls -la
 #### list of training folders 
 

--- a/k1_fundamentals/00_setup/README.md
+++ b/k1_fundamentals/00_setup/README.md
@@ -18,7 +18,7 @@ If you have docker, git and a common IDE installed locally, you can quickly star
 
 ```bash
 git clone https://github.com/kubermatic-labs/trainings.git
-docker run --name  kubeone-tool-container -v $(pwd):/home/kubermatic/mnt -t -d quay.io/kubermatic-labs/kubeone-tooling:1.2.3
+docker run --name kubeone-tool-container -v $(pwd):/home/kubermatic/mnt -t -d quay.io/kubermatic-labs/kubeone-tooling:1.2.3
 ```
 Connect into the running container and ensures that you can reattach if you get kicked out of the container:
 
@@ -32,7 +32,7 @@ docker exec -it kubeone-tool-container bash
 # remove old container
 docker rm -f kubeone-tool-container
 
-docker run --rm --name  kubeone-tool-container -v $(pwd):/home/kubermatic/mnt -it quay.io/kubermatic-labs/kubeone-tooling:1.2.3 bash
+docker run --rm --name kubeone-tool-container -v $(pwd):/home/kubermatic/mnt -it quay.io/kubermatic-labs/kubeone-tooling:1.2.3 bash
 ```
 
 ### (Alternative) Use Google Cloud Shell
@@ -51,7 +51,7 @@ export TRAINING_DIR=`pwd`/mnt/trainings/k1_fundamentals
 cd $TRAINING_DIR
 
 ls -la
-#### list of training folders 
+#### list of training folders
 
 kubeone version
 #### version json with kubeone v1.2.3 should be shown

--- a/k1_fundamentals/01_create-cloud-credentials/README.md
+++ b/k1_fundamentals/01_create-cloud-credentials/README.md
@@ -27,8 +27,7 @@ gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member serviceAccount:$
 gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member serviceAccount:$GCP_SERVICE_ACCOUNT_ID --role='roles/storage.admin'
 
 # create a new json key for your service account
-# training-repo => folder 'k1_fundamentals'
-cd [training-repo]
+cd $TRAINING_DIR # folder 'k1_fundamentals'
 mkdir -p ./.secrets && cd ./.secrets
 gcloud iam service-accounts keys create --iam-account $GCP_SERVICE_ACCOUNT_ID k8c-cluster-provisioner-sa-key.json
 ``` 
@@ -45,6 +44,6 @@ Test if your environment variable contains the json key
 ```bash
 echo $GOOGLE_CREDENTIALS 
 { "type": "service_account", "project_id": "YOUR PROJECT", "private_key_id": "..." }
-# jump back to [training-repo]
+# jump back to k1_fundamentals dir
 cd -
 ```

--- a/k1_fundamentals/02_initial-cloud-infra-with-terraform/README.md
+++ b/k1_fundamentals/02_initial-cloud-infra-with-terraform/README.md
@@ -6,8 +6,7 @@ To avoid the usage of your recent private SSH key, you can freshly create one fo
 
 ```bash
 # SSH Key creation if no ssh key is present
-
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
+cd $TRAINING_DIR # folder 'k1_fundamentals'
 ssh-keygen -f .secrets/id_rsa
 ### for now no password is needed, but for prodution would be recommended
 
@@ -19,7 +18,7 @@ ls -la .secrets/id*
 Change your folder to the GCE terraform folder [`src/gce/tf-infra`](src/gce/tf-infra) for our terraform GCE code (You will find more terraform examples in the KubeOne repo: [`./examples/terraform/`](https://github.com/kubermatic/kubeone/tree/master/examples/terraform)). 
 
 ```bash
-cd src/gce/tf-infra
+cd $TRAINING_DIR/src/gce/tf-infra
 terraform init
 ```
 

--- a/k1_fundamentals/03_first-kubeone-cluster/README.md
+++ b/k1_fundamentals/03_first-kubeone-cluster/README.md
@@ -20,7 +20,7 @@ cloudProvider:
 Start the KubeOne installation:
 
 ```bash
-cd [training-repo]/src/gce #training-repo => folder 'k1_fundamentals'
+cd $TRAINING_DIR/src/gce
 kubeone install -t ./tf-infra -m kubeone.yaml --verbose
 ```
 
@@ -35,7 +35,7 @@ As to not having to input these values manually to create the machine-controller
 **Alternative** You could also export the Terraform output into a tf.json file and use this one (not recommended, but makes the used content more visible):
 
 ```bash
-cd tf-infra
+cd $TRAINING_DIR/src/gce/tf-infra
 terraform output -json > tf.json
 cd ..
 kubeone install --tfjson tf.json --verbose

--- a/k1_fundamentals/03_first-kubeone-cluster/README.md
+++ b/k1_fundamentals/03_first-kubeone-cluster/README.md
@@ -191,4 +191,10 @@ Now we should see, one master and one worker node with the corresponding machine
 kubectl -n kube-system get machinedeployment,machineset,machine,node
 ```
 
-You can check the official KubeOne installation documentation for further reference: https://docs.kubermatic.com/kubeone/master/tutorials/
+Check the Cloud Controller Manager credentials (used for provisioning worker nodes).
+
+```bash
+kubectl get secret -n kube-system cloud-provider-credentials -o jsonpath='{.data.GOOGLE_SERVICE_ACCOUNT}' | base64 -d | base64 -d
+```
+
+This Secret is created by KubeOne and used when creating MachineDeployment by `machine-controller`.

--- a/k1_fundamentals/05_HA-master/README.md
+++ b/k1_fundamentals/05_HA-master/README.md
@@ -25,8 +25,7 @@ Save and execute the change:
 
 ```bash
 ### create the missing infrastructure
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
-cd ./src/gce/tf-infra
+cd $TRAINING_DIR/src/gce/tf-infra
 terraform apply
 ### install the missing master nodes with KubeOne
 kubeone apply -t . --manifest ../kubeone.yaml --verbose

--- a/k1_fundamentals/06_HA-worker/README.md
+++ b/k1_fundamentals/06_HA-worker/README.md
@@ -36,8 +36,7 @@ kubectl config set-context --current --namespace=kube-system
 kcns kube-system
 
 # export current machine deployment
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
-cd ./src/gce
+cd $TRAINING_DIR/src/gce
 mkdir machines     
 kubectl get machinedeployment k1-pool-az-a -o yaml | kexp > machines/md-zone-a.yaml
 
@@ -130,7 +129,7 @@ output "kubeone_workers" {
 ```
 
 ```bash
-cd tf-infra
+cd $TRAINING_DIR/src/gce/tf-infra
 vim output.tf
 terraform apply
 ```

--- a/k1_fundamentals/07_deploy-app-02-external-access/README.md
+++ b/k1_fundamentals/07_deploy-app-02-external-access/README.md
@@ -115,8 +115,7 @@ NAME                                           TYPE   TTL    DATA
 **ATTENTION: view and edit the .yaml files before you apply !!!**
 
 ```bash
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
-cd 07_deploy-app-02-external-access
+cd $TRAINING_DIR/07_deploy-app-02-external-access
 export TRAINING_EMAIL=student-XX.XXXX@loodse.training       #Use email provided by trainer for training
 sed -i "s/your-email@example.com/$TRAINING_EMAIL/g" manifests/lb.cluster-issuer.yaml
 kubectl apply -f manifests/lb.cluster-issuer.yaml

--- a/k1_fundamentals/08_optimize-workers/README.md
+++ b/k1_fundamentals/08_optimize-workers/README.md
@@ -27,9 +27,7 @@ Due to this we want to:
 As we already created our MachineDeployment yaml definitions, we can now easily update them and apply the change. For a full list of options of the machine deployment spec, see [github.com/kubermatic/machine-controller - examples/gce-machinedeployment.yaml](https://github.com/kubermatic/machine-controller/blob/master/examples/gce-machinedeployment.yaml).
 
 ```bash
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
-
-cd ./src/gce
+cd $TRAINING_DIR/src/gce
 ls -l machines/
 ```
 
@@ -266,8 +264,7 @@ kubectl -n kube-system scale machinedeployment --all --replicas=1
 We won't use the `app-ext` anymore, so you can safely clean the related resources.
 
 ```bash
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
-cd 07_deploy-app-02-external-access
+cd $TRAINING_DIR/07_deploy-app-02-external-access
 # delete application manifests
 kubectl delete -f manifests/
 # delete namespace

--- a/k1_fundamentals/09_backup_velero/README.md
+++ b/k1_fundamentals/09_backup_velero/README.md
@@ -10,7 +10,7 @@ We will now create a backup into a GCP bucket, for more details see the Velero G
 ### Create a Bucket
 
 ```bash
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
+cd $TRAINING_DIR # folder 'k1_fundamentals'
 cp ./09_backup_velero/gs-bucket.tf ./src/gce/tf-infra/
 cd ./src/gce/tf-infra
 

--- a/k1_fundamentals/10_addons-sc-and-restic-etcd-backup/README.md
+++ b/k1_fundamentals/10_addons-sc-and-restic-etcd-backup/README.md
@@ -22,7 +22,7 @@ Some "raw" Addons can be found here:
 If you take a look in your current cluster, currently no storage class is applied. If you create a new Persistent Volume Claim, no storage get applied.
 
 ```bash
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
+cd $TRAINING_DIR # folder 'k1_fundamentals'
 kubectl get sc
 ```
 
@@ -98,8 +98,7 @@ This config seams to look fine for our KubeOne cluster as well. As the cloud con
 Now let's create a new addon for our setup with the above Storage Class.
 
 ```bash
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
-cd src/gce
+cd $TRAINING_DIR/src/gce
 
 #first create the storage class manifest fest file
 mkdir "addons"
@@ -229,8 +228,7 @@ To prevent to manage Google Service Account credential secret, we can use the [K
 Now let's copy the template and adjust the needed `<<TODO_xxxx>>` parameters to our lab environment:
 
 ```bash
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
-cd src/gce
+cd $TRAINING_DIR/src/gce
 
 cp ../../10_addons-sc-and-restic-etcd-backup/template.backups-restic.yaml addons/gs.backups-restic.yaml
 vim addons/gs.backups-restic.yaml

--- a/k1_fundamentals/11_kubeone_upgrade/README.md
+++ b/k1_fundamentals/11_kubeone_upgrade/README.md
@@ -52,7 +52,7 @@ echo $GOOGLE_CREDENTIALS
 # should output the credentials, if not continue with below step
 
 # if empty see 00_setup chapter and execute
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
+cd $TRAINING_DIR # folder 'k1_fundamentals'
 export GOOGLE_CREDENTIALS=$(cat ./.secrets/k8c-cluster-provisioner-sa-key.json)
 ```
 
@@ -69,7 +69,7 @@ ssh-add -l
 *Hint: If empty or your ssh-agent is not running, add your SSH identity file:*
 
 ```bash
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
+cd $TRAINING_DIR # folder 'k1_fundamentals'
 eval `ssh-agent`
 ssh-add .secrets/id_rsa
 ```
@@ -110,7 +110,7 @@ To watch the upgrade process, open a **SECOND shell**:
 ### if you use the tooling conainer, open a new shell, do again
 docker exec -it kubeone-tool-container bash
 
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
+cd $TRAINING_DIR # folder 'k1_fundamentals'
 export KUBECONFIG=`pwd`/src/gce/k1-kubeconfig
 watch kubectl get md,ms,ma,nodes -A
 ```
@@ -123,7 +123,7 @@ The first approach to upgrade the cluster is to combine the upgrade of both the 
 
 ```bash
 # ensure latest terraform information are loaded
-cd src/gce/tf-infra
+cd $TRAINING_DIR/src/gce/tf-infra
 terraform refresh
 
 kubeone apply -t . -m ../kubeone.yaml --upgrade-machine-deployments --verbose

--- a/k1_fundamentals/12_cluster-autoscaling/README.md
+++ b/k1_fundamentals/12_cluster-autoscaling/README.md
@@ -5,8 +5,7 @@ First we need to deploy the cluster autoscaler controller. As reference take a l
 For this lab, current version is added here: [`./cluster-autoscaler.yaml`](./cluster-autoscaler.yaml), so first copy this to the KubeOne folder:
 
 ```bash
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
-cd src/gce
+cd $TRAINING_DIR/src/gce
 cp ../../12_cluster-autoscaling/cluster-autoscaler.yaml ./addons/
 
 ### Deploy the autoscaler addon

--- a/k1_fundamentals/99_cluster-cleanup-or-pause/README.md
+++ b/k1_fundamentals/99_cluster-cleanup-or-pause/README.md
@@ -7,8 +7,7 @@ To cleanup your cloud resource, KubeOne tool will support you.
 In the first step KubeOne will remove the worker nodes and reset the control plane nodes to the state before you installed Kubernetes. The command is also helpful if during the installation something breaks, and you don't want to re-provision all machines:
 
 ```bash
-cd [training-repo] #training-repo => folder 'k1_fundamentals'
-cd src/gce
+cd $TRAINING_DIR/src/gce
 kubeone reset -t ./tf-infra
 ```
 
@@ -20,7 +19,7 @@ As a last step, you should destroy your Terraform infrastructure. The next comma
 - The Kubernetes API Load Balancer
 
 ```bash
-cd tf-infra
+cd $TRAINING_DIR/src/gce/tf-infra
 terraform destroy
 ```
 

--- a/kkp_fundamentals/00-prepare-training-lab/README.md
+++ b/kkp_fundamentals/00-prepare-training-lab/README.md
@@ -21,7 +21,7 @@ If you have docker, git and a common IDE installed locally, you can quickly star
 
 ```bash
 git clone https://github.com/kubermatic-labs/trainings.git
-docker run --name  kubeone-tool-container -v $(pwd)/trainings:/home/kubermatic/mnt -t -d quay.io/kubermatic-labs/kubeone-tooling:1.2.3
+docker run --name kubeone-tool-container -v $(pwd):/home/kubermatic/mnt -t -d quay.io/kubermatic-labs/kubeone-tooling:1.2.3
 docker exec -it kubeone-tool-container bash
 ```
 
@@ -37,10 +37,11 @@ After you entered the container, verify the setup:
 
 ```bash
 ### executed inside the tooling container
+export TRAINING_DIR=`pwd`/mnt/trainings/kkp_fundamentals
+cd $TRAINING_DIR
 
-#### list of training folders
-cd ~/mnt/kkp_fundamentals/
 ls -la
+#### list of training folders
 
 #### version json with kubeone v1.2.3 should be shown
 kubeone version

--- a/kkp_fundamentals/01-kubeone-cluster-setup/README.md
+++ b/kkp_fundamentals/01-kubeone-cluster-setup/README.md
@@ -12,7 +12,7 @@ If you did the k1 fundamentals labs, feel free to copy the needed secrets to you
 
 ``` bash
 ### copy the secrets
-cp -r ~/mnt/k1_fundamentals/.secrets ~/mnt/kkp_fundamentals/
+cp -r $TRAINING_DIR/../k1_fundamentals/.secrets $TRAINING_DIR
 ```
 
 **Note - If you did the K1 fundamentals labs, please ensure that you destroyed the former KubeOne Cluster and DNS records with [../../k1_fundamentals/99_cluster-cleanup-or-pause](../../k1_fundamentals/99_cluster-cleanup-or-pause)!**
@@ -21,7 +21,7 @@ cp -r ~/mnt/k1_fundamentals/.secrets ~/mnt/kkp_fundamentals/
 
 ```bash
 ##### Ensure that you execute below commands inside of the tooling container
-cd ~/mnt/kkp_fundamentals/
+cd $TRAINING_DIR # folder 'kkp_fundamentals'
 mkdir ./.secrets && cd ./.secrets
 
 # ensure you are connected and get your Project ID
@@ -71,13 +71,13 @@ Run the following to provision the KubeOne cluster:
 
 ```bash
 # copy the template to your source folder
-cd ~/mnt/kkp_fundamentals/
+cd $TRAINING_DIR # folder 'kkp_fundamentals'
 cp -r 01-kubeone-cluster-setup/kkp-master.template src/kkp-master
 
 export GCP_PROJECT_ID=__YOUR_GCP_PROJECT_ID__                  # student-XX-xxxx
 
 # replace TODO-YOUR-GCP-PROJECT-ID with your project id 
-cd ~/mnt/kkp_fundamentals/src/kkp-master
+cd $TRAINING_DIR/src/kkp-master
 find . -type f -exec sed -i 's/TODO-YOUR-GCP-PROJECT-ID/'"$GCP_PROJECT_ID"'/g' {} +
 
 # start SSH agent and add id_rsa

--- a/kkp_fundamentals/02-kkp-master-setup/README.md
+++ b/kkp_fundamentals/02-kkp-master-setup/README.md
@@ -7,8 +7,8 @@ This chapter explains the installation procedure of KKP into a pre-existing Kube
 Again for simplicity of training we have the predefined manifests at [`./kkp-setup.template`](./kkp-setup.template). Copy it to `src` directory using below commands.
 
 ```bash
-cp -r ~/mnt/kkp_fundamentals/02-kkp-master-setup/kkp-setup.template ~/mnt/kkp_fundamentals/src/kkp-setup
-cd ~/mnt/kkp_fundamentals/src/kkp-setup
+cp -r $TRAINING_DIR/02-kkp-master-setup/kkp-setup.template $TRAINING_DIR/src/kkp-setup
+cd $TRAINING_DIR/src/kkp-setup
 ```
 
 ## Prepare KKP Configuration

--- a/kkp_fundamentals/03-master-dns-setup/README.md
+++ b/kkp_fundamentals/03-master-dns-setup/README.md
@@ -12,7 +12,7 @@ For reference see the Docs: [Kubermatic Docs - Install Kubermatic - Create DNS R
 First of all start a DNS zone editing transaction.:
 
 ```bash
-cd ~/mnt/kkp_fundamentals/src/kkp-setup
+cd $TRAINING_DIR/src/kkp-setup
 # get your gcloud DNS_ZONE
 gcloud dns managed-zones list
 ```
@@ -165,7 +165,7 @@ oauth        dex-tls          True    dex-tls          letsencrypt-prod   Certif
 You should now be able to open the KKP Dashboard and login with your configured e-mail ID of user at your `values.yaml`, for example: `student-XX-xxxx@loodse.training` and password `password`. You can check configured values by following command.
 
 ```bash
-cd ~/mnt/kkp_fundamentals/src/kkp-setup
+cd $TRAINING_DIR/src/kkp-setup
 grep -A 5 static values.yaml
 ```
 

--- a/kkp_fundamentals/04-add-seed-cluster/README.md
+++ b/kkp_fundamentals/04-add-seed-cluster/README.md
@@ -16,21 +16,21 @@ To add seed cluster to the Kubermatic master, you need to
 To connect the seed cluster with the master, you need to create a kubeconfig Secret.
 
 ```bash
-cd ~/mnt/kkp_fundamentals/
+cd $TRAINING_DIR # folder 'kkp_fundamentals'
 # create copy of current kubeconfig
-cp $KUBECONFIG ~/mnt/kkp_fundamentals/src/kkp-setup/temp-seed-kubeconfig
+cp $KUBECONFIG $TRAINING_DIR/src/kkp-setup/temp-seed-kubeconfig
 ```
 
 We need to convert the `temp-seed-kubeconfig` file to a Kubernetes Secret `seed-kubeconfig`.
 
 ```bash
-kubectl create secret generic seed-kubeconfig -n kubermatic --from-file kubeconfig=~/mnt/kkp_fundamentals/src/kkp-setup/temp-seed-kubeconfig --dry-run=client -o yaml > ~/mnt/kkp_fundamentals/src/kkp-setup/seed.kubeconfig.secret.yaml
+kubectl create secret generic seed-kubeconfig -n kubermatic --from-file kubeconfig=$TRAINING_DIR/src/kkp-setup/temp-seed-kubeconfig --dry-run=client -o yaml > $TRAINING_DIR/src/kkp-setup/seed.kubeconfig.secret.yaml
 ```
 
 Verify that the secret `seed-kubeconfig` has been created correctly by executing the following command and making sure the output looks similar to the example output afterwards.
 
 ```bash
-cat ~/mnt/kkp_fundamentals/src/kkp-setup/seed.kubeconfig.secret.yaml
+cat $TRAINING_DIR/src/kkp-setup/seed.kubeconfig.secret.yaml
 ```
 
 ```yaml
@@ -47,9 +47,9 @@ metadata:
 If everything looks fine, apply the secret and delete the temp file.
 
 ```bash
-kubectl apply -n kubermatic -f ~/mnt/kkp_fundamentals/src/kkp-setup/seed.kubeconfig.secret.yaml
+kubectl apply -n kubermatic -f $TRAINING_DIR/src/kkp-setup/seed.kubeconfig.secret.yaml
 ## cleanup
-rm ~/mnt/kkp_fundamentals/src/kkp-setup/temp-seed-kubeconfig
+rm $TRAINING_DIR/src/kkp-setup/temp-seed-kubeconfig
 ```
 
 ## Create seed resource
@@ -57,7 +57,7 @@ rm ~/mnt/kkp_fundamentals/src/kkp-setup/temp-seed-kubeconfig
 Take a look at the seed configuration file.
 
 ```bash
-cat ~/mnt/kkp_fundamentals/04-add-seed-cluster/seed.europe-west.yaml
+cat $TRAINING_DIR/04-add-seed-cluster/seed.europe-west.yaml
 ```
 
 ```yaml
@@ -109,9 +109,9 @@ Let's apply the manifest above in the master cluster. Kubermatic will pick up th
 
 ```bash
 # create copy of seed template
-cp ~/mnt/kkp_fundamentals/04-add-seed-cluster/seed.europe-west.yaml ~/mnt/kkp_fundamentals/src/kkp-setup/
+cp $TRAINING_DIR/04-add-seed-cluster/seed.europe-west.yaml $TRAINING_DIR/src/kkp-setup/
 # apply the config change
-kubectl apply -n kubermatic -f ~/mnt/kkp_fundamentals/src/kkp-setup/seed.europe-west.yaml
+kubectl apply -n kubermatic -f $TRAINING_DIR/src/kkp-setup/seed.europe-west.yaml
 ```
 
 ## Verify Seed deployment
@@ -207,19 +207,19 @@ kubermatic-fast   kubernetes.io/gce-pd   Delete          Immediate           fal
 So we want to set up a dedicated `kubermatic-backup` storage class. See [`./gce.sc.kubermatic.backup.yaml`](./gce.sc.kubermatic.backup.yaml) and create a copy in your `kkp-setup` folder.
 
 ```bash
-cp ~/mnt/kkp_fundamentals/04-add-seed-cluster/gce.sc.kubermatic.backup.yaml ~/mnt/kkp_fundamentals/src/kkp-setup
+cp $TRAINING_DIR/04-add-seed-cluster/gce.sc.kubermatic.backup.yaml $TRAINING_DIR/src/kkp-setup
 ```
 
 Check the configuration. For more details about the storage class parameters of the Google CCM, see [Kubernetes Storage Class - GCE PD](https://kubernetes.io/docs/concepts/storage/storage-classes/#gce-pd).
 
 ```bash
-cat ~/mnt/kkp_fundamentals/src/kkp-setup/gce.sc.kubermatic.backup.yaml
+cat $TRAINING_DIR/src/kkp-setup/gce.sc.kubermatic.backup.yaml
 ```
 
 When everything looks fine, apply the new storage class.
 
 ```bash
-kubectl apply -f ~/mnt/kkp_fundamentals/src/kkp-setup/gce.sc.kubermatic.backup.yaml
+kubectl apply -f $TRAINING_DIR/src/kkp-setup/gce.sc.kubermatic.backup.yaml
 ```
 
 Check that you now have a new storage class installed:
@@ -255,7 +255,7 @@ It's also advisable to install the  [S3 Backup Exporter](https://github.com/kube
 Now install the charts.
 
 ```bash
-cd ~/mnt/kkp_fundamentals/
+cd $TRAINING_DIR # folder 'kkp_fundamentals'
 helm upgrade --install --create-namespace --wait --values ./src/kkp-setup/values.yaml --namespace minio minio ./src/kkp-setup/releases/v2.17.3/charts/minio
 helm upgrade --install --wait --values ./src/kkp-setup/values.yaml --namespace kube-system s3-exporter ./src/kkp-setup/releases/v2.17.3/charts/s3-exporter/
 ```

--- a/kkp_fundamentals/06-create-user-cluster/README.md
+++ b/kkp_fundamentals/06-create-user-cluster/README.md
@@ -11,7 +11,7 @@ For the authentication with Google use your already created service account from
 To add the credentials in the Kubermatic UI, encode it as base64 and copy it:
 
 ```bash
-cd ~/mnt/kkp_fundamentals
+cd $TRAINING_DIR # folder 'kkp_fundamentals'
 base64 -w 0 ./.secrets/k8c-cluster-provisioner-sa-key.json
 ```
 


### PR DESCRIPTION
In both K1 & KKP trainings.

Based on feedback from Interhyp to allow better copy & paste of the code blocks.