### PR TITLE
Kubernetes Cluster version upgrade related validation issues fixes to the manifest and documentation

### DIFF
--- a/k8s_fundamentals/00_setup/setup_cluster.sh
+++ b/k8s_fundamentals/00_setup/setup_cluster.sh
@@ -54,7 +54,7 @@ then
     --network "projects/$PROJECT_NAME/global/networks/$NETWORK_NAME" --subnetwork "projects/$PROJECT_NAME/regions/$REGION/subnetworks/$NETWORK_NAME-subnet" \
     --services-ipv4-cidr=10.0.1.0/24 --default-max-pods-per-node=110 \
     --zone=$ZONE \
-    --cluster-version 1.20.10-gke.301 \
+    --cluster-version $CLUSTER_VERSION \
     --machine-type "n1-standard-4" --num-nodes "2" \
     --image-type "UBUNTU" --disk-type "pd-standard" --disk-size "100" \
     --enable-network-policy --enable-ip-alias \

--- a/k8s_fundamentals/22_ingress/README.md
+++ b/k8s_fundamentals/22_ingress/README.md
@@ -23,7 +23,9 @@ kubectl get pods,svc
 ```
 
 ## Inspect and create the resources for the ingress controller
-
+> Before you start, create role binding 
+> - With user account -> using `gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member user:$GCP_USER_ACCOUNT --role='roles/container.admin'` where set the values of parameters `GCP_PROJECT_ID` to your project and `GCP_USER_ACCOUNT` to your user account.
+> - With serviceaccount -> using `gcloud projects add-iam-policy-binding $GCP_PROJECT_ID --member serviceAccount:$GCP_SERVICE_ACCOUNT_ID --role='roles/container.admin'` where set the values of parameters `GCP_PROJECT_ID` to your project and `GCP_SERVICE_ACCOUNT_ID` to your service account.
 ```bash
 kubectl create -f ingress-controller-rbac.yaml
 kubectl create -f ingress-controller-deployment.yaml

--- a/k8s_fundamentals/22_ingress/ingress-controller-rbac.yaml
+++ b/k8s_fundamentals/22_ingress/ingress-controller-rbac.yaml
@@ -4,7 +4,7 @@ metadata:
   name: traefik-ingress-controller
 ---
 kind: ClusterRole
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-ingress-controller
 rules:
@@ -20,6 +20,7 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - "networking.k8s.io"
     resources:
       - ingresses
     verbs:
@@ -28,13 +29,14 @@ rules:
       - watch
   - apiGroups:
       - extensions
+      - "networking.k8s.io"
     resources:
       - ingresses/status
     verbs:
       - update
 ---
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: traefik-ingress-controller
 roleRef:

--- a/k8s_fundamentals/22_ingress/ingress.yaml
+++ b/k8s_fundamentals/22_ingress/ingress.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: my-ingress
@@ -11,10 +11,16 @@ spec:
     - http:
         paths:
           - path: /red
+            pathType: Exact
             backend:
-              serviceName: red
-              servicePort: 80
+              service:
+                name: red
+                port: 
+                  number: 80
           - path: /blue
+            pathType: Exact
             backend:
-              serviceName: blue
-              servicePort: 80
+              service:
+                name: blue
+                port:
+                  number: 80


### PR DESCRIPTION
…arameter.

- Updated notes for pre-requisite role binding setup required for creating clusterrole and clusterrolebinding. Reference to the issue
`Error from server (Forbidden): error when creating "": clusterroles.rbac.authorization.k8s.io is forbidden: User "xxx@xxx.com" cannot create resource "clusterroles" in API group "rbac.authorization.k8s.io" at the cluster scope: requires one of ["container.clusterRoles.create"] permission(s).`
- Fixed ingress from `extensions/v1beta1` to `networking.k8s.io/v1`, clusterrolebinding from `rbac.authorization.k8s.io/v1beta1` to `rbac.authorization.k8s.io/v1` and clusterrole from `rbac.authorization.k8s.io/v1beta1` to `rbac.authorization.k8s.io/v1` manifests.
- Updated the apiGroups for ingresses
- Adapted to the definition specs as per ingress manifest updates. Reference validation errors:

`[ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "servicePort" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[1].backend): unknown field "serviceName" in io.k8s.api.networking.v1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[1].backend): unknown field "servicePort" in io.k8s.api.networking.v1.IngressBackend]; if you choose to ignore these errors, turn
validation off with --validate=false`

`The Ingress "my-ingress" is invalid: * spec.rules[0].http.paths[0].pathType: Required value: pathType must be specified * spec.rules[0].http.paths[1].pathType: Required value: pathType must be specified`