### PR TITLE
Fixed for CronJob's Kind related warning

### DIFF
--- a/k1_fundamentals/10_addons-sc-and-restic-etcd-backup/template.backups-restic.yaml
+++ b/k1_fundamentals/10_addons-sc-and-restic-etcd-backup/template.backups-restic.yaml
@@ -16,7 +16,7 @@ type: Opaque
 data:
   password: {{ "<<TODO_RESTIC_PASSWORD>>" | b64enc }}
 ---
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: etcd-gs-backup

--- a/k8s_fundamentals/18_cronjobs/cronjob.yaml
+++ b/k8s_fundamentals/18_cronjobs/cronjob.yaml
@@ -1,4 +1,4 @@
-apiVersion: batch/v1beta1
+apiVersion: batch/v1
 kind: CronJob
 metadata:
   name: my-cronjob


### PR DESCRIPTION
Fix for below warning message
```
W0517 15:13:43.885386    2656 warnings.go:70] batch/v1beta1 CronJob is deprecated in v1.21+, unavailable in v1.25+; use batch/v1 CronJob
```

Signed-off-by: archups <archupsawant@gmail.com>